### PR TITLE
[extend-sqs-support] Support MessageAttributes and Attributes fields for SQS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sfn-sim",
-  "version": "1.5.1",
+  "version": "2.0.0",
   "description": "AWS Step Functions simulator for unit testing state machines",
   "keywords": [
     "aws",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -35,9 +35,23 @@ export interface SNSResource extends Resource {
   messages: string[];
 }
 
+export interface SQSMessageAttributes {
+  [key: string]: {
+    StringValue: string,
+    DataType: string,
+  }
+}
+
+export interface SQSMessage {
+  MessageBody: string,
+  MessageAttributes?: SQSMessageAttributes,
+  MessageDeduplicationId?: string,
+  MessageGroupId?: string,
+}
+
 export interface SQSResource extends Resource {
   service: 'sqs';
-  messages: string[];
+  messages: SQSMessage[];
 }
 
 export interface CloudwatchResource extends Resource {

--- a/src/task.js
+++ b/src/task.js
@@ -177,13 +177,14 @@ const runSnsTask = (action, resource, input) => {
 };
 
 const runSqsTask = (action, resource, input) => {
-  const { MessageBody, MessageAttributes, Attributes } = input;
+  const { MessageBody, MessageAttributes, MessageDeduplicationId, MessageGroupId } = input;
 
   if (action === 'sendMessage') {
     resource.messages.push({
       MessageBody,
       ...(MessageAttributes !== undefined && { MessageAttributes }),
-      ...(Attributes !== undefined && { Attributes }),
+      ...(MessageDeduplicationId !== undefined && { MessageDeduplicationId }),
+      ...(MessageGroupId !== undefined && { MessageGroupId }),
     });
     return input;
   }

--- a/src/task.js
+++ b/src/task.js
@@ -177,10 +177,14 @@ const runSnsTask = (action, resource, input) => {
 };
 
 const runSqsTask = (action, resource, input) => {
-  const { MessageBody } = input;
+  const { MessageBody, MessageAttributes, Attributes } = input;
 
   if (action === 'sendMessage') {
-    resource.messages.push(MessageBody);
+    resource.messages.push({
+      MessageBody,
+      ...(MessageAttributes !== undefined && { MessageAttributes }),
+      ...(Attributes !== undefined && { Attributes }),
+    });
     return input;
   }
 

--- a/tests/task.test.js
+++ b/tests/task.test.js
@@ -522,10 +522,8 @@ describe('sqs', () => {
             DataType: 'String'
           },
         },
-        Attributes: {
-          MessageGroupId: 0,
-          MessageDeduplicationId: '1111-1111-1111-1111',
-        },
+        MessageDeduplicationId: '1111-1111-1111-1111',
+        MessageGroupId: '0',
       }
 
       const input = {

--- a/tests/task.test.js
+++ b/tests/task.test.js
@@ -517,11 +517,57 @@ describe('sqs', () => {
       const input = {
         QueueUrl: 'https://sqs.eu-west-1.amazonaws.com/012345678901/my-queue',
         MessageBody: 'someString',
+        MessageAttributes: {
+          correlationId: {
+            StringValue: 'someCorrelationId',
+            DataType: 'String'
+          },
+        },
+        Attributes: {
+          MessageGroupId: 0,
+          MessageDeduplicationId: '1111-1111-1111-1111',
+        },
       };
 
       await runTask(state, simulatorContext, input);
 
-      expect(messages).toContain('someString');
+      expect(messages).toContainEqual({
+        MessageBody: 'someString',
+        MessageAttributes: {
+          correlationId: {
+            StringValue: 'someCorrelationId',
+            DataType: 'String'
+          },
+        },
+        Attributes: {
+          MessageGroupId: 0,
+          MessageDeduplicationId: '1111-1111-1111-1111',
+        },
+      });
+    });
+
+    test('sends a message body to a queue', async () => {
+      const messages = [];
+      const simulatorContext = {
+        resources: [
+          {
+            service: 'sqs',
+            name: 'my-queue',
+            messages,
+          },
+        ],
+      };
+
+      const input = {
+        QueueUrl: 'https://sqs.eu-west-1.amazonaws.com/012345678901/my-queue',
+        MessageBody: 'someString',
+      };
+
+      await runTask(state, simulatorContext, input);
+
+      expect(messages).toContainEqual({
+        MessageBody: 'someString',
+      });
     });
   });
 

--- a/tests/task.test.js
+++ b/tests/task.test.js
@@ -514,8 +514,7 @@ describe('sqs', () => {
         ],
       };
 
-      const input = {
-        QueueUrl: 'https://sqs.eu-west-1.amazonaws.com/012345678901/my-queue',
+      const baseMessageFields = {
         MessageBody: 'someString',
         MessageAttributes: {
           correlationId: {
@@ -527,23 +526,16 @@ describe('sqs', () => {
           MessageGroupId: 0,
           MessageDeduplicationId: '1111-1111-1111-1111',
         },
+      }
+
+      const input = {
+        QueueUrl: 'https://sqs.eu-west-1.amazonaws.com/012345678901/my-queue',
+        ...baseMessageFields,
       };
 
       await runTask(state, simulatorContext, input);
 
-      expect(messages).toContainEqual({
-        MessageBody: 'someString',
-        MessageAttributes: {
-          correlationId: {
-            StringValue: 'someCorrelationId',
-            DataType: 'String'
-          },
-        },
-        Attributes: {
-          MessageGroupId: 0,
-          MessageDeduplicationId: '1111-1111-1111-1111',
-        },
-      });
+      expect(messages).toContainEqual(baseMessageFields);
     });
 
     test('sends a message body to a queue', async () => {


### PR DESCRIPTION
Add support for (optional) additional fields in SQS messages, `MessageAttributes` and `Attributes`. Example mock message below:

```
{
    MessageBody: 'someString',
    MessageAttributes: {
        'document.id': {
            StringValue: 'someDocumentId',
            DataType: 'String',
        },
    },
    MessageGroupId: 'main-group',
    MessageDeduplicationId: '1111-1111-1111-1111',
}
```

`MessageGroupId` and `MessageDeduplicationId` are use in FIFO queues, with `MessageGroupId` being required.